### PR TITLE
Fri 94/restrict test api calls to using UI client role

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ assets
 cypress.json
 reporter-config.json
 dist/
+test_results

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,35 @@
+import type { Config } from 'jest'
+
+const config: Config = {
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        isolatedModules: true,
+      },
+    ],
+  },
+  collectCoverage: true,
+  collectCoverageFrom: ['server/**/*.{ts,js,jsx,mjs}'],
+  coverageDirectory: 'test_results/unit/coverage',
+  testMatch: ['<rootDir>/(server|job)/**/?(*.)(cy|test).{ts,js,jsx,mjs}'],
+  testEnvironment: 'node',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'test_results/jest/',
+      },
+    ],
+    [
+      './node_modules/jest-html-reporter',
+      {
+        outputPath: 'test_results/unit-test-reports.html',
+      },
+    ],
+  ],
+  moduleFileExtensions: ['web.js', 'js', 'json', 'node', 'ts'],
+}
+
+export default config

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "prettier-plugin-jinja-template": "^2.0.0",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
+        "ts-node": "^10.9.2",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.11.0"
       },
@@ -1459,6 +1460,30 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@cypress/request": {
@@ -3394,6 +3419,34 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4029,6 +4082,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
@@ -4212,6 +4278,13 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5457,6 +5530,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -13399,6 +13479,60 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -13753,6 +13887,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -14119,6 +14260,16 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -27,45 +27,6 @@
     "node": "^20",
     "npm": "^10"
   },
-  "jest": {
-    "transform": {
-      "^.+\\.tsx?$": [
-        "ts-jest",
-        {
-          "isolatedModules": true
-        }
-      ]
-    },
-    "collectCoverageFrom": [
-      "server/**/*.{ts,js,jsx,mjs}"
-    ],
-    "testMatch": [
-      "<rootDir>/(server|job)/**/?(*.)(cy|test).{ts,js,jsx,mjs}"
-    ],
-    "testEnvironment": "node",
-    "reporters": [
-      "default",
-      [
-        "jest-junit",
-        {
-          "outputDirectory": "test_results/jest/"
-        }
-      ],
-      [
-        "./node_modules/jest-html-reporter",
-        {
-          "outputPath": "test_results/unit-test-reports.html"
-        }
-      ]
-    ],
-    "moduleFileExtensions": [
-      "web.js",
-      "js",
-      "json",
-      "node",
-      "ts"
-    ]
-  },
   "lint-staged": {
     "*.{ts,js,css}": [
       "prettier --write",
@@ -154,6 +115,7 @@
     "prettier-plugin-jinja-template": "^2.0.0",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.11.0"
   },

--- a/server/@types/hmppsAuth/index.d.ts
+++ b/server/@types/hmppsAuth/index.d.ts
@@ -1,0 +1,1 @@
+export type SystemToken = string

--- a/server/applicationInfo.ts
+++ b/server/applicationInfo.ts
@@ -14,7 +14,10 @@ export type ApplicationInfo = {
 }
 
 export default (): ApplicationInfo => {
-  const packageJson = path.join(__dirname, '../../package.json')
+  const packageJson =
+    process.env.NODE_ENV !== 'test'
+      ? path.join(__dirname, '../../package.json')
+      : path.join(__dirname, '../package.json')
   const { name: applicationName } = JSON.parse(fs.readFileSync(packageJson).toString())
   return { applicationName, buildNumber, gitRef, gitShortHash: gitRef.substring(0, 7), productId, branchName }
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -78,7 +78,11 @@ export default {
       agent: new AgentConfig(Number(get('HMPPS_AUTH_TIMEOUT_RESPONSE', 10000))),
       authClientId: get('AUTH_CODE_CLIENT_ID', 'hmpps-find-and-refer-an-intervention-ui', requiredInProduction),
       authClientSecret: get('AUTH_CODE_CLIENT_SECRET', 'clientsecret', requiredInProduction),
-      systemClientId: get('CLIENT_CREDS_CLIENT_ID', 'hmpps-find-and-refer-an-intervention-ui', requiredInProduction),
+      systemClientId: get(
+        'CLIENT_CREDS_CLIENT_ID',
+        'hmpps-find-and-refer-an-intervention-ui-client',
+        requiredInProduction,
+      ),
       systemClientSecret: get('CLIENT_CREDS_CLIENT_SECRET', 'clientsecret', requiredInProduction),
     },
     findAndReferService: {

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -3,21 +3,27 @@
  * Do appinsights first as it does some magic instrumentation work, i.e. it affects other 'require's
  * In particular, applicationinsights automatically collects bunyan logs
  */
-import { initialiseAppInsights, buildAppInsightsClient } from '../utils/azureAppInsights'
 import applicationInfoSupplier from '../applicationInfo'
+import { buildAppInsightsClient, initialiseAppInsights } from '../utils/azureAppInsights'
 
 const applicationInfo = applicationInfoSupplier()
 initialiseAppInsights()
 buildAppInsightsClient(applicationInfo)
 
-import HmppsAuthClient from './hmppsAuthClient'
-import { createRedisClient } from './redisClient'
-import RedisTokenStore from './tokenStore/redisTokenStore'
-import InMemoryTokenStore from './tokenStore/inMemoryTokenStore'
 import config from '../config'
 import HmppsAuditClient from './hmppsAuditClient'
+import HmppsAuthClient from './hmppsAuthClient'
+import { createRedisClient } from './redisClient'
+import InMemoryTokenStore from './tokenStore/inMemoryTokenStore'
+import RedisTokenStore from './tokenStore/redisTokenStore'
 
-type RestClientBuilder<T> = (token: string) => T
+type RestClientBuilder<T> = (token: Express.User['token']) => T
+type RestClientBuilderWithoutToken<T> = () => T
+
+// This should be changed to a redis client when redis is implemented properly
+const tokenStore = new InMemoryTokenStore()
+
+const hmppsAuthClientBuilder: RestClientBuilderWithoutToken<HmppsAuthClient> = () => new HmppsAuthClient(tokenStore)
 
 export const dataAccess = () => ({
   applicationInfo,
@@ -29,4 +35,4 @@ export const dataAccess = () => ({
 
 export type DataAccess = ReturnType<typeof dataAccess>
 
-export { HmppsAuthClient, RestClientBuilder, HmppsAuditClient }
+export { HmppsAuditClient, HmppsAuthClient, hmppsAuthClientBuilder, RestClientBuilder, RestClientBuilderWithoutToken }

--- a/server/routes/test/testController.ts
+++ b/server/routes/test/testController.ts
@@ -1,13 +1,14 @@
 import { Request, Response } from 'express'
-import TestView from './testView'
-import ControllerUtils from '../../utils/controllerUtils'
 import FindAndReferService from '../../services/findAndReferService'
+import ControllerUtils from '../../utils/controllerUtils'
+import TestView from './testView'
 
 export default class TestController {
   constructor(private readonly findAndReferService: FindAndReferService) {}
 
   async showTestPage(req: Request, res: Response): Promise<void> {
-    const dummy = await this.findAndReferService.getDummy(res.locals.user.token, '1')
+    const { username } = req.user
+    const dummy = await this.findAndReferService.getDummy('1', username)
     const view = new TestView(dummy)
 
     ControllerUtils.renderWithLayout(res, view)

--- a/server/services/findAndReferService.test.ts
+++ b/server/services/findAndReferService.test.ts
@@ -1,18 +1,37 @@
-import FindAndReferService from './findAndReferService'
 import config from '../config'
+import { HmppsAuthClient } from '../data'
 import RestClient from '../data/restClient'
+import InMemoryTokenStore from '../data/tokenStore/inMemoryTokenStore'
 import MockRestClient from '../testutils/mockRestClient'
+import FindAndReferService from './findAndReferService'
 
 // wraps mocking API around the class exported by the module
 jest.mock('../data/restClient')
+jest.mock('../data/hmppsAuthClient')
+
+// This will likely have to be changed to redis client once implemented
+const tokenStore = new InMemoryTokenStore() as jest.Mocked<InMemoryTokenStore>
+const systemToken = 'TEST_SYSTEM_TOKEN'
+const username = 'TEST_USERNAME'
+
+const hmppsAuthClient = new HmppsAuthClient(tokenStore) as jest.Mocked<HmppsAuthClient>
+const hmppsAuthClientBuilder = jest.fn()
+const restClientMock = new MockRestClient(config.apis.findAndReferService) as jest.Mocked<RestClient>
+const findAndReferService = new FindAndReferService(hmppsAuthClientBuilder)
+
+beforeEach(() => {
+  jest.resetAllMocks()
+
+  hmppsAuthClientBuilder.mockReturnValue(hmppsAuthClient)
+  hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+  findAndReferService.createRestClient = jest.fn().mockReturnValue(restClientMock)
+})
 
 describe('Find and Refer Service', () => {
-  const findAndReferService = new FindAndReferService()
-  const restClientMock = new MockRestClient(config.apis.findAndReferService) as jest.Mocked<RestClient>
-  findAndReferService.createRestClient = jest.fn().mockReturnValue(restClientMock)
-
   it('should call get dummy data with the correct params', async () => {
-    await findAndReferService.getDummy('secretToken', '12345')
+    const result = await findAndReferService.getDummy('12345', username)
+    expect(hmppsAuthClientBuilder).toHaveBeenCalled()
+    expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     expect(restClientMock.get).toHaveBeenCalledWith({ headers: { Accept: 'application/json' }, path: '/dummy/12345' })
   })
 })

--- a/server/services/findAndReferService.test.ts
+++ b/server/services/findAndReferService.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 
 describe('Find and Refer Service', () => {
   it('should call get dummy data with the correct params', async () => {
-    const result = await findAndReferService.getDummy('12345', username)
+    await findAndReferService.getDummy('12345', username)
     expect(hmppsAuthClientBuilder).toHaveBeenCalled()
     expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     expect(restClientMock.get).toHaveBeenCalledWith({ headers: { Accept: 'application/json' }, path: '/dummy/12345' })

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,4 +1,4 @@
-import { dataAccess } from '../data'
+import { dataAccess, hmppsAuthClientBuilder } from '../data'
 import AuditService from './auditService'
 import FindAndReferService from './findAndReferService'
 
@@ -6,7 +6,7 @@ export const services = () => {
   const { applicationInfo, hmppsAuditClient } = dataAccess()
 
   const auditService = new AuditService(hmppsAuditClient)
-  const findAndReferService = new FindAndReferService()
+  const findAndReferService = new FindAndReferService(hmppsAuthClientBuilder)
   return {
     applicationInfo,
     auditService,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,14 @@
       "@hmpps-auth": ["./server/@types/hmppsAuth/index.d.ts"]
     }
   },
-  "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist", "cypress.config.ts", "esbuild"],
+  "exclude": [
+    "node_modules",
+    "assets/**/*.js",
+    "integration_tests",
+    "dist",
+    "cypress.config.ts",
+    "esbuild",
+    "test_results"
+  ],
   "include": ["**/*.js", "**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,10 @@
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
     "experimentalDecorators": true,
-    "typeRoots": ["./server/@types", "./node_modules/@types"]
+    "typeRoots": ["./server/@types", "./node_modules/@types"],
+    "paths": {
+      "@hmpps-auth": ["./server/@types/hmppsAuth/index.d.ts"]
+    }
   },
   "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist", "cypress.config.ts", "esbuild"],
   "include": ["**/*.js", "**/*.ts"]


### PR DESCRIPTION
This PR ensures that the correct system client role is added to the Find and Refer service client when making calls to the backend.

To retrieve the system client role we must first make a call to HMPPS Auth using the client username. This will then obtain the correct role related to the hmpps-find-and-refer-an-intervention-ui-client oAuth clientId.