### PR TITLE
FRI-283: Update intervention type to include TOOLKITS rather than TOOL

### DIFF
--- a/server/catalogue/routes/cataloguePresenter.test.ts
+++ b/server/catalogue/routes/cataloguePresenter.test.ts
@@ -1,5 +1,5 @@
-import CataloguePresenter from './cataloguePresenter'
 import CatalogueFilter from './catalogueFilter'
+import CataloguePresenter from './cataloguePresenter'
 
 describe(`mapInterventionTypeToFriendlyString`, () => {
   it('returns the correct mapping', async () => {
@@ -31,7 +31,7 @@ describe(`filters.`, () => {
   describe(`intervention type`, () => {
     it('set to true if set in filter', async () => {
       const filter = new CatalogueFilter()
-      filter.interventionType = ['ACP', 'CRS', 'SI', 'TOOL', 'ROIF', 'CFO']
+      filter.interventionType = ['ACP', 'CRS', 'SI', 'TOOLKITS', 'ROIF', 'CFO']
 
       const presenter = new CataloguePresenter(
         {
@@ -103,7 +103,7 @@ describe(`filters.`, () => {
           checked: false,
         },
         {
-          value: 'TOOL',
+          value: 'TOOLKITS',
           text: 'Toolkits',
           checked: false,
         },

--- a/server/catalogue/routes/cataloguePresenter.ts
+++ b/server/catalogue/routes/cataloguePresenter.ts
@@ -1,7 +1,7 @@
-import { ListStyle, SummaryListItem } from '../../utils/summaryList'
-import Pagination from '../../utils/pagination/pagination'
-import { Page } from '../../shared/models/pagination'
 import InterventionCatalogueItem from '../../models/InterventionCatalogueItem'
+import { Page } from '../../shared/models/pagination'
+import Pagination from '../../utils/pagination/pagination'
+import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 import CatalogueFilter from './catalogueFilter'
 
 export default class CataloguePresenter {
@@ -127,9 +127,9 @@ export default class CataloguePresenter {
       checked: this.filter.interventionType?.includes('SI') ?? false,
     },
     {
-      value: 'TOOL',
+      value: 'TOOLKITS',
       text: 'Toolkits',
-      checked: this.filter.interventionType?.includes('TOOL') ?? false,
+      checked: this.filter.interventionType?.includes('TOOLKITS') ?? false,
     },
   ]
 


### PR DESCRIPTION
This PR updates the `Intervention Type` enum to use the correct value for the Toolkit type. The API expects a value of `TOOLKITS` to be passed.