### PR TITLE
Add robert.mercury to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,8 @@ System tokens are obtained by making a call to HMPPS-Auth using the username of 
 
 Once the application is running you should then be able to login with:
 
-username: AUTH_USER
+username: robert.mercury
 password: password123456
-
-To request specific users and roles then raise a PR
-to [update the seed data](https://github.com/ministryofjustice/hmpps-auth/blob/main/src/main/resources/db/dev/data/auth/V900_3__users.sql)
-for the in-memory DB used by Auth
 
 ## Extra commands
 


### PR DESCRIPTION
**WHAT**

This PR changes out the previous username in the README (`AUTH_USER`) for the one we actually use (`robert.mercury`).

It also removes the unclear comment about adding permissions via a PR to a SQL file.
