### PR TITLE
wrap text inside tag box so it doesn't overflow onto the rest of page

### DIFF
--- a/assets/scss/components/_catalogue.scss
+++ b/assets/scss/components/_catalogue.scss
@@ -8,3 +8,7 @@
     font-size: 16px;
   }
 }
+
+.moj-filter__tag {
+    overflow-wrap: anywhere;
+}


### PR DESCRIPTION
Prevent filter tag text from overflowing onto page

![image](https://github.com/user-attachments/assets/dd325cd3-cc9c-4118-9b51-666776cf68ed)
