### PR TITLE
No ticket/small UI tweaks

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -11,7 +11,7 @@ export default function nunjucksSetup(app: express.Express): void {
   app.set('view engine', 'njk')
 
   app.locals.asset_path = '/assets/'
-  app.locals.applicationName = 'HMPPS Find and refer an intervention'
+  app.locals.applicationName = 'Find and refer an intervention'
   app.locals.environmentName = config.environmentName
   app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
   app.locals.applicationInsightsConnectionString = config.applicationInsights.connectionString || ''

--- a/server/views/intervention/intervention.njk
+++ b/server/views/intervention/intervention.njk
@@ -37,14 +37,15 @@
       {% endif %}
 
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8">Location:</h2>
       {% if presenter.setting == 'custody' and presenter.intervention.custodyLocations.length > 0 %}
-        <p class="govuk-body govuk-!-margin-top-6">{{ presenter.text.custodyLocationDescription }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8">Location:</h2>
+      <p class="govuk-body govuk-!-margin-top-6">{{ presenter.text.custodyLocationDescription }}</p>
         {{ govukTable(presenter.getLocationsInCustodyTableArgs()) }}
       {% endif %}
 
       {% if presenter.setting == 'community' and presenter.intervention.communityLocations.length > 0 %}
-        <p class="govuk-body govuk-!-margin-top-6">{{ presenter.text.communityLocationDescription }}</p>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8">Location:</h2>
+      <p class="govuk-body govuk-!-margin-top-6">{{ presenter.text.communityLocationDescription }}</p>
         {% macro locationTable(pdus) %}
             {% set rows = [] %}
             {% for pdu in pdus %}

--- a/server/views/intervention/intervention.njk
+++ b/server/views/intervention/intervention.njk
@@ -21,30 +21,30 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-8">Criteria</h2>
       {{ govukSummaryList(summaryListArgs(presenter.interventionSummaryList())) }}
 
-      <h2 class="govuk-heading-m govuk-!-margin-top-8">Description:</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8">Description</h2>
       <p>{{ presenter.intervention.description }}</p>
 
       {% if presenter.intervention.interventionType == 'CRS' %}
-           <h2 class="govuk-heading-m govuk-!-margin-top-8">Outcomes:</h2>
+           <h2 class="govuk-heading-m govuk-!-margin-top-8">Outcomes</h2>
              {% for outcome in presenter.intervention.expectedOutcomes %}
              <p>{{ outcome }}</p>
              {% endfor %}
       {% endif %}
 
       {% if presenter.intervention.sessionDetails %}
-           <h2 class="govuk-heading-m govuk-!-margin-top-8">Session Details:</h2>
+           <h2 class="govuk-heading-m govuk-!-margin-top-8">Session Details</h2>
           <p>{{ presenter.intervention.sessionDetails}}</p>
       {% endif %}
 
 
       {% if presenter.setting == 'custody' and presenter.intervention.custodyLocations.length > 0 %}
-      <h2 class="govuk-heading-m govuk-!-margin-top-8">Location:</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8">Location</h2>
       <p class="govuk-body govuk-!-margin-top-6">{{ presenter.text.custodyLocationDescription }}</p>
         {{ govukTable(presenter.getLocationsInCustodyTableArgs()) }}
       {% endif %}
 
       {% if presenter.setting == 'community' and presenter.intervention.communityLocations.length > 0 %}
-      <h2 class="govuk-heading-m govuk-!-margin-top-8">Location:</h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8">Location</h2>
       <p class="govuk-body govuk-!-margin-top-6">{{ presenter.text.communityLocationDescription }}</p>
         {% macro locationTable(pdus) %}
             {% set rows = [] %}
@@ -62,7 +62,7 @@
               },
               head: [
                 {
-                  text: "Name",
+                  text: "Probation Delivery Unit (PDU)",
                   attributes: {
                     "aria-sort": "ascending"
                   }


### PR DESCRIPTION
- in location, replace ‘name’ with ‘probation delivery unit’ (PDU)
- Remove colon in detail pages e.g. from description, outcomes, location
- remove duplication of HMPPS in banner - 'HMPPS HMPPS Find and Refer an Intervention’