### PR TITLE
Update data-test-id attribute to data-testid

### DIFF
--- a/server/views/catalogue/catalogue.njk
+++ b/server/views/catalogue/catalogue.njk
@@ -42,7 +42,7 @@
               },
               submit: {
                 attributes: {
-                    "data-test-id": "submit-button"
+                    "data-testid": "submit-button"
                 }
               },
             selectedFilters: selectedFilters,
@@ -53,7 +53,7 @@
     <p/>
 
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-s" data-test-id="results-number">{{presenter.pagination.page.totalElements}} results</h2>
+      <h2 class="govuk-heading-s" data-testid="results-number">{{presenter.pagination.page.totalElements}} results</h2>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
       {% if presenter.interventions.length == 0 %}

--- a/server/views/crsDetails/crsDetails.njk
+++ b/server/views/crsDetails/crsDetails.njk
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l" data-test-id="intervention-name">{{ presenter.crsDetails.npsRegion }}: {{presenter.crsDetails.title}}</h1>
+    <h1 class="govuk-heading-l" data-testid="intervention-name">{{ presenter.crsDetails.npsRegion }}: {{presenter.crsDetails.title}}</h1>
     <p>{{ presenter.crsDetails.description }}</p>
     {{ govukSummaryList(summaryListArgs(presenter.crsDetailsSummaryList())) }}
 

--- a/server/views/intervention/intervention.njk
+++ b/server/views/intervention/intervention.njk
@@ -14,7 +14,7 @@
 
 {{ govukBackLink(backLinkArgs) }}
 
-  <h1 class="govuk-heading-l intervention-heading" data-test-id="intervention-name">{{ presenter.text.pageHeading }}</h1>
+  <h1 class="govuk-heading-l intervention-heading" data-testid="intervention-name">{{ presenter.text.pageHeading }}</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 


### PR DESCRIPTION
Currently the playwright tests for our e2e tests are broken. One of the reasons is due to the fact we use a function getByTestId. This function expects the `data test id` attribute on a component to be `data-testid`. In Find and Refer we currently have this property set to `data-test-id`.

This PR updates the name of the attribute to what playwright will expect.

Playwright documentation: https://playwright.dev/docs/api/class-page#page-get-by-test-id