### PR TITLE
Add e2e tests into Circle ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2.1
 orbs:
   hmpps: ministryofjustice/hmpps@10
   slack: circleci/slack@4.12.5
+  node: circleci/node@4.5.2
+
 
 parameters:
   releases-slack-channel:
@@ -62,6 +64,29 @@ jobs:
       - store_artifacts:
           path: test_results/unit/xml
 
+  end_to_end_test:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.52.0-noble
+    circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
+    steps:
+      - run:
+          name: Clone E2E repo
+          command: |
+            git clone https://github.com/ministryofjustice/hmpps-find-and-refer-an-intervention-e2e .
+      - run:
+          name: Update npm
+          command: 'npm install -g npm@latest'
+      - node/install-packages
+      - run:
+          name: Install Playwright
+          command: npx playwright install --with-deps
+      - run:
+          name: E2E Check
+          command: |
+            npx playwright test
+      - store_artifacts:
+          path: playwright-report
+
 workflows:
   version: 2
   build-test-and-deploy:
@@ -110,10 +135,19 @@ workflows:
           requires:
             - deploy_dev
           helm_timeout: 5m
+      - end_to_end_test:
+          context: hmpps-common-vars
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - deploy_dev
       - request-prod-approval:
           type: approval
           requires:
             - deploy_preprod
+            - end_to_end_test
       - hmpps/deploy_env:
           name: deploy_prod
           env: 'prod'


### PR DESCRIPTION
This PR adds running the e2e tests from https://github.com/ministryofjustice/hmpps-find-and-refer-an-intervention-e2e into the UI project. This will run on `main` branch as atm the tests run against the dev environment.