### PR TITLE
FRI-534: allow internal connections on dev environment

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,6 +9,7 @@ generic-service:
   
   allowlist:
     groups:
+      - internal
       - circleci
 
   env:


### PR DESCRIPTION
WHAT:

This pr allows `internal` connections to the dev environment. Which means users on the vpn can connect to this environment.

WHY:

This was previously set by default in the `values.yml` of helm deploy. But a change was made to allow ingress from circleci in dev for the e2e tests to be ran. I wrongly thought it would add to the variables already there rather than overwrite so did not set to allow `internal` connections on dev. This pr now explicitly allows both types of connection.