### PR TITLE
FRI-515: Update risk criteria to be displayed in a specific order

### DIFF
--- a/server/catalogue/routes/cataloguePresenter.test.ts
+++ b/server/catalogue/routes/cataloguePresenter.test.ts
@@ -201,7 +201,8 @@ describe(`interventionSummaryList`, () => {
       },
       {
         key: 'Risk criteria',
-        lines: ['Medium, high or very high', 'Yes'],
+        lines: ['OVP: score 20+', 'If OVP not available, then OGRS3: score 25+', 'Low risk on SARA'],
+        listStyle: 1,
       },
       {
         key: 'Needs',
@@ -244,7 +245,8 @@ describe(`interventionSummaryList`, () => {
       },
       {
         key: 'Risk criteria',
-        lines: ['Medium, high or very high', 'Yes'],
+        lines: ['OVP: score 20+', 'If OVP not available, then OGRS3: score 25+', 'Low risk on SARA'],
+        listStyle: 1,
       },
       {
         key: 'Suitable for people with learning disabilities or challenges (LDC)',
@@ -356,7 +358,8 @@ describe(`interventionSummaryList`, () => {
       },
       {
         key: 'Risk criteria',
-        lines: ['Medium, high or very high', 'Yes'],
+        lines: ['OVP: score 20+', 'If OVP not available, then OGRS3: score 25+', 'Low risk on SARA'],
+        listStyle: 1,
       },
       {
         key: 'Needs',
@@ -402,7 +405,8 @@ describe(`interventionSummaryList`, () => {
       },
       {
         key: 'Risk criteria',
-        lines: ['Medium, high or very high', 'Yes'],
+        lines: ['OVP: score 20+', 'If OVP not available, then OGRS3: score 25+', 'Low risk on SARA'],
+        listStyle: 1,
       },
       {
         key: 'Needs',
@@ -448,7 +452,8 @@ describe(`interventionSummaryList`, () => {
       },
       {
         key: 'Risk criteria',
-        lines: ['Medium, high or very high', 'Yes'],
+        lines: ['OVP: score 20+', 'If OVP not available, then OGRS3: score 25+', 'Low risk on SARA'],
+        listStyle: 1,
       },
       {
         key: 'Needs',

--- a/server/catalogue/routes/cataloguePresenter.ts
+++ b/server/catalogue/routes/cataloguePresenter.ts
@@ -227,7 +227,7 @@ export default class CataloguePresenter {
 
     if (fieldsToShow.riskCriteria && intervention.riskCriteria) {
       const riskList = InterventionsUtils.formatRiskCriteriaObject(intervention.riskCriteria)
-      if (riskList.length !== 0) {
+      if (riskList !== null) {
         summary.push({
           key: 'Risk criteria',
           lines: riskList,

--- a/server/catalogue/routes/cataloguePresenter.ts
+++ b/server/catalogue/routes/cataloguePresenter.ts
@@ -225,11 +225,15 @@ export default class CataloguePresenter {
       },
     ]
 
-    if (fieldsToShow.riskCriteria && intervention.riskCriteria && intervention.riskCriteria.length > 0) {
-      summary.push({
-        key: 'Risk criteria',
-        lines: intervention.riskCriteria,
-      })
+    if (fieldsToShow.riskCriteria && intervention.riskCriteria) {
+      const riskList = InterventionsUtils.formatRiskCriteriaObject(intervention.riskCriteria)
+      if (riskList.length !== 0) {
+        summary.push({
+          key: 'Risk criteria',
+          lines: riskList,
+          listStyle: riskList.length > 1 ? ListStyle.bulleted : undefined,
+        })
+      }
     }
 
     if (fieldsToShow.criminogenicNeeds && intervention.criminogenicNeeds && intervention.criminogenicNeeds.length > 0) {

--- a/server/intervention/routes/InterventionPresenter.test.ts
+++ b/server/intervention/routes/InterventionPresenter.test.ts
@@ -30,7 +30,8 @@ describe(`interventionSummaryList`, () => {
       },
       {
         key: 'Risk criteria',
-        lines: ['Medium, high or very high', 'Yes'],
+        lines: ['OVP: score 20+', 'If OVP not available, then OGRS3: score 25+', 'Low risk on SARA'],
+        listStyle: 1,
       },
       {
         key: 'Time to complete',
@@ -65,7 +66,8 @@ describe(`interventionSummaryList`, () => {
       },
       {
         key: 'Risk criteria',
-        lines: ['Medium, high or very high', 'Yes'],
+        lines: ['OVP: score 20+', 'If OVP not available, then OGRS3: score 25+', 'Low risk on SARA'],
+        listStyle: 1,
       },
       {
         key: 'Suitable for people with learning disabilities or challenges (LDC)',
@@ -166,7 +168,8 @@ describe(`interventionSummaryList`, () => {
       },
       {
         key: 'Risk criteria',
-        lines: ['Medium, high or very high', 'Yes'],
+        lines: ['OVP: score 20+', 'If OVP not available, then OGRS3: score 25+', 'Low risk on SARA'],
+        listStyle: 1,
       },
       {
         key: 'Needs',
@@ -201,7 +204,8 @@ describe(`interventionSummaryList`, () => {
       },
       {
         key: 'Risk criteria',
-        lines: ['Medium, high or very high', 'Yes'],
+        lines: ['OVP: score 20+', 'If OVP not available, then OGRS3: score 25+', 'Low risk on SARA'],
+        listStyle: 1,
       },
       {
         key: 'Needs',
@@ -236,7 +240,8 @@ describe(`interventionSummaryList`, () => {
       },
       {
         key: 'Risk criteria',
-        lines: ['Medium, high or very high', 'Yes'],
+        lines: ['OVP: score 20+', 'If OVP not available, then OGRS3: score 25+', 'Low risk on SARA'],
+        listStyle: 1,
       },
       {
         key: 'Needs',
@@ -257,7 +262,7 @@ describe(`interventionSummaryList`, () => {
 
   it('returns a summarylist object without optional fields when they are not available', async () => {
     const interventionDetails = interventionDetailsFactory.build({
-      riskCriteria: [],
+      riskCriteria: null,
       suitableForPeopleWithLearningDifficulties: null,
       equivalentNonLdcProgramme: null,
       timeToComplete: null,

--- a/server/intervention/routes/interventionPresenter.ts
+++ b/server/intervention/routes/interventionPresenter.ts
@@ -35,7 +35,7 @@ export default class InterventionPresenter {
 
     if (fieldsToShow.riskCriteria && this.intervention.riskCriteria) {
       const riskList = InterventionsUtils.formatRiskCriteriaObject(this.intervention.riskCriteria)
-      if (riskList.length !== 0) {
+      if (riskList !== null) {
         summary.push({
           key: 'Risk criteria',
           lines: riskList,

--- a/server/intervention/routes/interventionPresenter.ts
+++ b/server/intervention/routes/interventionPresenter.ts
@@ -3,7 +3,7 @@ import InterventionDetails, { CustodyLocation, PDU } from '../../models/Interven
 import { AvailableInterventionDetailsFields, InterventionDetailsFields } from '../../utils/fieldUtils'
 import { TableArgs } from '../../utils/govukFrontendTypes'
 import InterventionsUtils from '../../utils/interventionUtils'
-import { SummaryListItem } from '../../utils/summaryList'
+import { ListStyle, SummaryListItem } from '../../utils/summaryList'
 
 export default class InterventionPresenter {
   constructor(
@@ -33,11 +33,15 @@ export default class InterventionPresenter {
       },
     ]
 
-    if (fieldsToShow.riskCriteria && this.intervention.riskCriteria && this.intervention.riskCriteria.length > 0) {
-      summary.push({
-        key: 'Risk criteria',
-        lines: this.intervention.riskCriteria,
-      })
+    if (fieldsToShow.riskCriteria && this.intervention.riskCriteria) {
+      const riskList = InterventionsUtils.formatRiskCriteriaObject(this.intervention.riskCriteria)
+      if (riskList.length !== 0) {
+        summary.push({
+          key: 'Risk criteria',
+          lines: riskList,
+          listStyle: riskList.length > 1 ? ListStyle.bulleted : undefined,
+        })
+      }
     }
 
     if (

--- a/server/models/InterventionCatalogueItem.ts
+++ b/server/models/InterventionCatalogueItem.ts
@@ -1,3 +1,5 @@
+import RiskCriteria from './RiskCriteria'
+
 export type InterventionType = 'SI' | 'ACP' | 'CRS' | 'TOOLKITS'
 export type DeliveryMethodSetting = 'COMMUNITY' | 'CUSTODY'
 
@@ -9,7 +11,7 @@ export default interface InterventionCatalogueItem {
   setting: DeliveryMethodSetting[]
   allowsMales: boolean
   allowsFemales: boolean
-  riskCriteria: string[]
+  riskCriteria?: RiskCriteria
   attendanceType: string
   deliveryFormat: string
   criminogenicNeeds: string[]

--- a/server/models/InterventionDetails.ts
+++ b/server/models/InterventionDetails.ts
@@ -1,4 +1,5 @@
 import { InterventionType } from './InterventionCatalogueItem'
+import RiskCriteria from './RiskCriteria'
 
 export interface PDU {
   id: string
@@ -25,7 +26,7 @@ export default interface InterventionDetails {
   title: string
   minAge?: number
   maxAge?: number
-  riskCriteria?: string[]
+  riskCriteria?: RiskCriteria
   suitableForPeopleWithLearningDifficulties?: string
   equivalentNonLdcProgramme?: string
   timeToComplete?: string

--- a/server/models/RiskCriteria.ts
+++ b/server/models/RiskCriteria.ts
@@ -1,0 +1,21 @@
+export default interface RiskCriteria {
+  cnScoreGuide?: string
+  extremismRiskGuide?: string
+  saraPartnerScoreGuide?: string
+  saraOtherScoreGuide?: string
+  ospScoreGuide?: string
+  ospDcIccCombinationGuide?: string
+  ogrsScoreGuide?: string
+  ovpGuide?: string
+  ogpGuide?: string
+  pnaGuide?: string
+  rsrGuide?: string
+  roshLevel?: RoshLevel
+}
+
+export enum RoshLevel {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  VERY_HIGH = 'VERY HIGH',
+}

--- a/server/utils/interventionUtils.ts
+++ b/server/utils/interventionUtils.ts
@@ -25,7 +25,7 @@ export default class InterventionsUtils {
 
   // The Criminogenic Needs Score (cnScoreGuide) has been excluded from this list as it should not be displayed alongside the risk criteria.
   static formatRiskCriteriaObject(riskCriteria: RiskCriteria) {
-    return [
+    const riskList: string[] = [
       riskCriteria.ovpGuide,
       riskCriteria.ogrsScoreGuide,
       riskCriteria.ogpGuide,
@@ -38,5 +38,6 @@ export default class InterventionsUtils {
       riskCriteria.rsrGuide,
       riskCriteria.roshLevel?.toString(),
     ].filter((item): item is string => item !== undefined)
+    return riskList.length > 0 ? riskList : null
   }
 }

--- a/server/utils/interventionUtils.ts
+++ b/server/utils/interventionUtils.ts
@@ -1,3 +1,5 @@
+import RiskCriteria from '../models/RiskCriteria'
+
 export default class InterventionsUtils {
   static formatGenderText(allowsMale: boolean, allowsFemale: boolean): string {
     if (allowsMale && allowsFemale) {
@@ -19,5 +21,22 @@ export default class InterventionsUtils {
     return InterventionTypes[interventionType.toUpperCase()] !== undefined
       ? InterventionTypes[interventionType.toUpperCase()]
       : ''
+  }
+
+  // The Criminogenic Needs Score (cnScoreGuide) has been excluded from this list as it should not be displayed alongside the risk criteria.
+  static formatRiskCriteriaObject(riskCriteria: RiskCriteria) {
+    return [
+      riskCriteria.ovpGuide,
+      riskCriteria.ogrsScoreGuide,
+      riskCriteria.ogpGuide,
+      riskCriteria.ospDcIccCombinationGuide,
+      riskCriteria.ospScoreGuide,
+      riskCriteria.extremismRiskGuide,
+      riskCriteria.saraPartnerScoreGuide,
+      riskCriteria.saraOtherScoreGuide,
+      riskCriteria.pnaGuide,
+      riskCriteria.rsrGuide,
+      riskCriteria.roshLevel?.toString(),
+    ].filter((item): item is string => item !== undefined)
   }
 }

--- a/testutils/factories/interventionCatalogueItem.ts
+++ b/testutils/factories/interventionCatalogueItem.ts
@@ -30,7 +30,7 @@ class InterventionCatalogueItemFactory extends Factory<InterventionCatalogueItem
   missingFields() {
     return this.params({
       criminogenicNeeds: [],
-      riskCriteria: [],
+      riskCriteria: null,
       timeToComplete: null,
     })
   }
@@ -48,7 +48,11 @@ export default InterventionCatalogueItemFactory.define(({ sequence }) => ({
   setting: ['CUSTODY' as DeliveryMethodSetting],
   allowsMales: true,
   allowsFemales: false,
-  riskCriteria: ['Medium, high or very high', 'Yes'],
+  riskCriteria: {
+    saraOtherScoreGuide: 'Low risk on SARA',
+    ogrsScoreGuide: 'If OVP not available, then OGRS3: score 25+',
+    ovpGuide: 'OVP: score 20+',
+  },
   attendanceType: 'In Person',
   deliveryFormat: 'Group',
   timeToComplete: 'At least 6 Months',

--- a/testutils/factories/interventionDetails.ts
+++ b/testutils/factories/interventionDetails.ts
@@ -80,7 +80,11 @@ export default InterventionDetailsFactory.define(({ sequence }) => ({
   setting: ['CUSTODY'],
   allowsMales: true,
   allowsFemales: false,
-  riskCriteria: ['Medium, high or very high', 'Yes'],
+  riskCriteria: {
+    saraOtherScoreGuide: 'Low risk on SARA',
+    ogrsScoreGuide: 'If OVP not available, then OGRS3: score 25+',
+    ovpGuide: 'OVP: score 20+',
+  },
   attendanceType: 'In Person',
   deliveryFormat: 'Group',
   timeToComplete: 'At least 6 Months',


### PR DESCRIPTION
This PR Updates the riskCriteria which is displayed in the summary and details pages the be displayed in a specific order as requested by the BA.

It also formats these as bulleted list if there is more than 1 entry.

![image](https://github.com/user-attachments/assets/0baf922f-0c32-4fac-8599-e850b5e45ddc)
